### PR TITLE
Render link only if prop is defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "increase-components",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/ProductButton/ProductButton.js
+++ b/src/components/ProductButton/ProductButton.js
@@ -49,11 +49,7 @@ const ProductButton = ({ productName, CTA, linkCTA, disabled }) => {
           <div className="product">{productName}</div>
         </div>
       </div>
-      {linkCTA ? (
-        <CTALink href={linkCTA}>{CTA}</CTALink>
-      ) : (
-          ''
-      )}
+      {linkCTA ? <CTALink href={linkCTA}>{CTA}</CTALink> : ''}
     </ButtonWrapper>
   );
 };

--- a/src/components/ProductButton/ProductButton.js
+++ b/src/components/ProductButton/ProductButton.js
@@ -49,7 +49,11 @@ const ProductButton = ({ productName, CTA, linkCTA, disabled }) => {
           <div className="product">{productName}</div>
         </div>
       </div>
-      <CTALink href={linkCTA}>{CTA}</CTALink>
+      {linkCTA ? (
+        <CTALink href={linkCTA}>{CTA}</CTALink>
+      ) : (
+          ''
+      )}
     </ButtonWrapper>
   );
 };


### PR DESCRIPTION
Fixed problem when CTA is not defined.

This problem cause sizing issues when I try to use this component without CTA.


**Original**
<img width="718" alt="image" src="https://user-images.githubusercontent.com/955591/51185886-19a77f00-18b7-11e9-9fc8-f7df141da090.png">

**Fixed**
<img width="718" alt="image" src="https://user-images.githubusercontent.com/955591/51185930-2deb7c00-18b7-11e9-8dd1-76a278d370ee.png">

