### PR TITLE
Update table and link styles

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,14 +1,29 @@
+import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import NewTheme from '../../themes/new';
 
-const Link = styled.a`
-  color: #3b86ff;
+const LinkStyles = styled.a`
+  color: ${(props) =>
+    props.variant === 'alert' ? props.theme.colors.redTint : props.theme.colors.lightBlueRegular};
   text-decoration: none;
+  pointer-events: ${(props) => (props.disabled ? 'none' : '')};
+  opacity: ${(props) => (props.disabled ? '.25' : '1')};
 `;
+LinkStyles.defaultProps = { theme: NewTheme };
 
-export default Link;
+const Link = ({ variant, disabled, href, children }) => (
+  <LinkStyles disabled={disabled} href={href} variant={variant}>
+    {children}
+  </LinkStyles>
+);
 
 Link.propTypes = {
   children: PropTypes.node,
-  href: PropTypes.string
+  href: PropTypes.string,
+  variant: PropTypes.oneOf(['normal', 'alert'])
 };
+
+Link.defaultProps = { variant: 'normal' };
+
+export default Link;

--- a/src/components/Link/Link.stories.js
+++ b/src/components/Link/Link.stories.js
@@ -5,5 +5,16 @@ import { storiesOf } from '@storybook/react';
 import Link from './Link';
 
 storiesOf('Link', module).add('to a normal url', () => (
-  <Link href="https://www.google.com.ar">www.google.com.ar</Link>
+  <>
+    <Link href="https://www.google.com.ar">www.google.com.ar</Link>
+    <Link disabled href="https://www.google.com.ar">
+      www.google.com.ar
+    </Link>
+    <Link href="https://www.google.com.ar" variant="alert">
+      www.google.com.ar
+    </Link>
+    <Link disabled href="https://www.google.com.ar" variant="alert">
+      www.google.com.ar
+    </Link>
+  </>
 ));

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -12,9 +12,7 @@ const defaultProps = {
 };
 
 export const Table = styled.table`
-  border: 1px solid ${(props) => props.theme.colors.grayShade};
   border-collapse: collapse;
-  font-family: 'Open Sans';
 `;
 
 export default Table;

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -6,6 +6,9 @@ import TableRowExpandable from './TableRowExpandable';
 import TableData from './TableData';
 import TableHeader from './TableHeader';
 import TableHead from './TableHead';
+import Select from '../Select/Select';
+import SelectItem from '../Select/SelectItem';
+import Link from '../Link/Link';
 
 storiesOf('Table', module)
   .add('normal', () => (
@@ -35,7 +38,21 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>Imaginación</TableData>
+          <TableData>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link variant="alert" href="https://A link">
+              A link
+            </Link>
+          </TableData>
         </TableRow>
         <TableRow>
           <TableData>19/03/2018</TableData>
@@ -47,7 +64,21 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>Imaginación</TableData>
+          <TableData>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link variant="alert" href="https://A link">
+              A link
+            </Link>
+          </TableData>
         </TableRow>
         <TableRow>
           <TableData>19/03/2018</TableData>
@@ -59,7 +90,21 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>Imaginación</TableData>
+          <TableData>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link variant="alert" href="https://A link">
+              A link
+            </Link>
+          </TableData>
         </TableRow>
       </tbody>
     </Table>

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -219,7 +219,7 @@ storiesOf('Table', module)
           <TableData number>$ 0,00</TableData>
           <TableData number>$ 0,00</TableData>
         </TableRowExpandable>
-        <TableRow style={{ backgroundColor: '#008000', color: 'white' }}>
+        <TableRow style={{ backgroundColor: '#295DB1', color: 'white' }}>
           <TableHead style={{ paddingLeft: '38px' }}>Acreditado</TableHead>
           <TableData number>$ 0,00</TableData>
           <TableData number>$ 0,00</TableData>

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -11,8 +11,8 @@ import SelectItem from '../Select/SelectItem';
 import Link from '../Link/Link';
 
 storiesOf('Table', module)
-  .add('normal', () => (
-    <Table style={{ width: '1000px' }}>
+  .add('Normal', () => (
+    <Table style={{ width: '100%' }}>
       <TableHeader>
         <TableRow>
           <TableHead>Fecha de venta</TableHead>
@@ -38,21 +38,7 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>
-            <Select id="number">
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Select id="number">
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Link variant="alert" href="https://A link">
-              A link
-            </Link>
-          </TableData>
+          <TableData>Imaginación</TableData>
         </TableRow>
         <TableRow>
           <TableData>19/03/2018</TableData>
@@ -64,21 +50,7 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>
-            <Select id="number">
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Select id="number">
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Link variant="alert" href="https://A link">
-              A link
-            </Link>
-          </TableData>
+          <TableData>Imaginación</TableData>
         </TableRow>
         <TableRow>
           <TableData>19/03/2018</TableData>
@@ -90,13 +62,69 @@ storiesOf('Table', module)
           <TableData number>1685</TableData>
           <TableData number>586</TableData>
           <TableData number>0284</TableData>
-          <TableData>
-            <Select id="number">
+          <TableData>Imaginación</TableData>
+        </TableRow>
+      </tbody>
+    </Table>
+  ))
+  .add('Inline Elements', () => (
+    <Table style={{ width: '100%' }}>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Producto</TableHead>
+          <TableHead>Valor mensual</TableHead>
+          <TableHead>Forma de pago</TableHead>
+        </TableRow>
+      </TableHeader>
+      <tbody>
+        <TableRow>
+          <TableData>Card</TableData>
+          <TableData>$320 + IVA</TableData>
+          <TableData inline>
+            <Select id="number" labelHidden>
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Select id="number">
+            <Select id="number" labelHidden>
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link variant="alert" href="https://A link">
+              A link
+            </Link>
+          </TableData>
+        </TableRow>
+        <TableRow>
+          <TableData>Card</TableData>
+          <TableData>$320 + IVA</TableData>
+          <TableData inline>
+            <Select id="number" labelHidden>
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number" labelHidden>
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link variant="alert" href="https://A link">
+              A link
+            </Link>
+          </TableData>
+        </TableRow>
+        <TableRow>
+          <TableData>Card</TableData>
+          <TableData>$320 + IVA</TableData>
+          <TableData inline>
+            <Select id="number" labelHidden>
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number" labelHidden>
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
@@ -109,8 +137,8 @@ storiesOf('Table', module)
       </tbody>
     </Table>
   ))
-  .add('expandable', () => (
-    <Table style={{ width: '800px' }}>
+  .add('Expandable', () => (
+    <Table style={{ width: '100%' }}>
       <TableHeader>
         <TableRow>
           <TableHead />

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -81,31 +81,12 @@ storiesOf('Table', module)
           <TableData>Card</TableData>
           <TableData>$320 + IVA</TableData>
           <TableData inline>
-            <Select id="number" labelHidden>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Select id="number" labelHidden>
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Link href="#" variant="alert">
-              A link
-            </Link>
-          </TableData>
-        </TableRow>
-        <TableRow>
-          <TableData>Card</TableData>
-          <TableData>$320 + IVA</TableData>
-          <TableData inline>
-            <Select id="number" labelHidden>
-              <SelectItem text="One Option" value="1" />
-              <SelectItem text="Another Option" value="2" />
-              <SelectItem text="Yet Another Option" value="3" />
-            </Select>
-            <Select id="number" labelHidden>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
@@ -119,12 +100,31 @@ storiesOf('Table', module)
           <TableData>Card</TableData>
           <TableData>$320 + IVA</TableData>
           <TableData inline>
-            <Select id="number" labelHidden>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Select id="number" labelHidden>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Link href="#" variant="alert">
+              A link
+            </Link>
+          </TableData>
+        </TableRow>
+        <TableRow>
+          <TableData>Card</TableData>
+          <TableData>$320 + IVA</TableData>
+          <TableData inline>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
+              <SelectItem text="One Option" value="1" />
+              <SelectItem text="Another Option" value="2" />
+              <SelectItem text="Yet Another Option" value="3" />
+            </Select>
+            <Select id="number" labelHidden labelText="Selector de ejemplo">
               <SelectItem text="One Option" value="1" />
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -91,7 +91,7 @@ storiesOf('Table', module)
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Link variant="alert" href="https://A link">
+            <Link href="#" variant="alert">
               A link
             </Link>
           </TableData>
@@ -110,7 +110,7 @@ storiesOf('Table', module)
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Link variant="alert" href="https://A link">
+            <Link href="#" variant="alert">
               A link
             </Link>
           </TableData>
@@ -129,7 +129,7 @@ storiesOf('Table', module)
               <SelectItem text="Another Option" value="2" />
               <SelectItem text="Yet Another Option" value="3" />
             </Select>
-            <Link variant="alert" href="https://A link">
+            <Link href="#" variant="alert">
               A link
             </Link>
           </TableData>

--- a/src/components/Table/TableData.js
+++ b/src/components/Table/TableData.js
@@ -14,9 +14,13 @@ const defaultProps = {
 };
 
 export const TableData = styled.td`
-  border-bottom: 1px solid ${(props) => props.theme.colors.brandBlueRegular};
   padding: 20px 10px;
   text-align: ${(props) => (props.number ? 'right' : 'left')};
+  display: ${(props) => (props.inline ? 'flex' : 'table-cell')};
+  align-items: center;
+  & > * {
+    margin-right: 1rem;
+  }
 `;
 
 export default TableData;

--- a/src/components/Table/TableData.js
+++ b/src/components/Table/TableData.js
@@ -14,7 +14,7 @@ const defaultProps = {
 };
 
 export const TableData = styled.td`
-  border-bottom: 1px solid ${(props) => props.theme.colors.grayShade};
+  border-bottom: 1px solid ${(props) => props.theme.colors.brandBlueRegular};
   padding: 20px 10px;
   text-align: ${(props) => (props.number ? 'right' : 'left')};
 `;

--- a/src/components/Table/TableData.js
+++ b/src/components/Table/TableData.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import newTheme from '../../themes/new';
@@ -16,15 +16,7 @@ const defaultProps = {
 export const TableData = styled.td`
   border-bottom: 1px solid ${(props) => props.theme.colors.grayShade};
   padding: 20px 10px;
-
-  ${(props) =>
-    props.number
-      ? css`
-          text-align: right;
-        `
-      : css`
-          text-align: left;
-        `};
+  text-align: ${(props) => (props.number ? 'right' : 'left')};
 `;
 
 export default TableData;

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import newTheme from '../../themes/new';
@@ -16,15 +16,7 @@ const defaultProps = {
 export const TableHead = styled.th`
   border-bottom: 1px solid ${(props) => props.theme.colors.grayShade};
   padding: 20px 10px;
-
-  ${(props) =>
-    props.number
-      ? css`
-          text-align: right;
-        `
-      : css`
-          text-align: left;
-        `};
+  text-align: ${(props) => (props.number ? 'right' : 'left')};
 `;
 
 export default TableHead;

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -14,7 +14,7 @@ const defaultProps = {
 };
 
 export const TableHead = styled.th`
-  border-bottom: 1px solid ${(props) => props.theme.colors.grayShade};
+  border-bottom: 1px solid ${(props) => props.theme.colors.brandBlueRegular};
   padding: 20px 10px;
   text-align: ${(props) => (props.number ? 'right' : 'left')};
 `;

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -14,7 +14,6 @@ const defaultProps = {
 };
 
 export const TableHead = styled.th`
-  border-bottom: 1px solid ${(props) => props.theme.colors.brandBlueRegular};
   padding: 20px 10px;
   text-align: ${(props) => (props.number ? 'right' : 'left')};
 `;

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -14,6 +14,7 @@ const defaultProps = {
 export const TableHeader = styled.thead`
   color: ${(props) => props.theme.colors.brandBlueRegular};
   font-weight: bold;
+  vertical-align: bottom;
 `;
 
 export default TableHeader;

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -12,7 +12,6 @@ const defaultProps = {
 };
 
 export const TableHeader = styled.thead`
-  background-color: #f2f6f7;
   color: ${(props) => props.theme.colors.brandBlueRegular};
   font-weight: bold;
 `;

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -15,6 +15,9 @@ export const TableHeader = styled.thead`
   color: ${(props) => props.theme.colors.brandBlueRegular};
   font-weight: bold;
   vertical-align: bottom;
+  tr:hover {
+    background-color: initial;
+  }
 `;
 
 export default TableHeader;

--- a/src/components/Table/TableRow.js
+++ b/src/components/Table/TableRow.js
@@ -24,7 +24,6 @@ export const TableRow = styled.tr`
   ${(props) =>
     props.inset &&
     css`
-      background-color: #f7f7f7;
       border-left: 2px solid ${insetBorderColor};
       & > td:first-child {
         padding-left: 38px;

--- a/src/components/Table/TableRow.js
+++ b/src/components/Table/TableRow.js
@@ -20,7 +20,7 @@ const insetBorderColor = (props) =>
 
 export const TableRow = styled.tr`
   color: ${fontColor};
-  border-bottom: 1px solid ${(props) => (props.theme.colors.brandBlueRegular)};
+  border-bottom: 1px solid ${(props) => props.theme.colors.brandBlueRegular};
   ${(props) =>
     props.inset &&
     css`

--- a/src/components/Table/TableRow.js
+++ b/src/components/Table/TableRow.js
@@ -20,7 +20,7 @@ const insetBorderColor = (props) =>
 
 export const TableRow = styled.tr`
   color: ${fontColor};
-  height: 60px;
+  border-bottom: 1px solid ${(props) => (props.theme.colors.brandBlueRegular)};
   ${(props) =>
     props.inset &&
     css`
@@ -31,14 +31,6 @@ export const TableRow = styled.tr`
       }
     `} &:hover {
     background-color: #f7f7f7;
-  }
-  & > th:first-child,
-  & > td:first-child {
-    padding-left: 26px;
-  }
-  & > th:last-child,
-  & > td:last-child {
-    padding-right: 26px;
   }
 `;
 

--- a/src/components/Table/TableRowExpandable.js
+++ b/src/components/Table/TableRowExpandable.js
@@ -37,11 +37,7 @@ const Wrapper = styled(TableRow)`
     display: inline-block;
     height: 16px;
     width: 16px;
-    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTc5MiIg
-aGVpZ2h0PSIxNzkyIiB2aWV3Qm94PSIwIDAgMTc5MiAxNzkyIiB4bWxucz0iaHR0cDovL3d3dy53
-My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0xMTUyIDg5NnEwIDI2LTE5IDQ1bC00NDggNDQ4cS0x
-OSAxOS00NSAxOXQtNDUtMTktMTktNDV2LTg5NnEwLTI2IDE5LTQ1dDQ1LTE5IDQ1IDE5bDQ0OCA0
-NDhxMTkgMTkgMTkgNDV6Ii8+PC9zdmc+);
+    background-image: url(data:image/svg+xml;base64PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB3aWR0aD0iMTc5MiIgaGVpZ2h0PSIxNzkyIiB2aWV3Qm94PSIwIDAgMTc5MiAxNzkyIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik0xMTUyIDg5NnEwIDI2LTE5IDQ1bC00NDggNDQ4cS0xOSAxOS00NSAxOXQtNDUtMTktMTktNDV2LTg5NnEwLTI2IDE5LTQ1dDQ1LTE5IDQ1IDE5bDQ0OCA0NDhxMTkgMTkgMTkgNDV6Ii8+PC9zdmc+);
     ${(props) =>
       props.expanded &&
       css`


### PR DESCRIPTION
- Se agrega `variant="alert"` a los estilos de `Link`
<img width="175" alt="image" src="https://user-images.githubusercontent.com/955591/51682298-d095b000-1fc5-11e9-8d24-9c90fde4d173.png">

- Se agrega una nueva prop `inline`, para sar en los casos que hay más de un elemento en una única celda.
<img width="998" alt="image" src="https://user-images.githubusercontent.com/955591/51682354-fae76d80-1fc5-11e9-9ec9-00076a879569.png">

- Cambios generales en los estilos de `Table` para que se aproxime a los estilos del Sistema de Diseño ->
<img width="992" alt="image" src="https://user-images.githubusercontent.com/955591/51682581-8103b400-1fc6-11e9-88ce-8afe02e3383b.png">
