### PR TITLE
Fix scrollable content

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -214,7 +214,7 @@ class Modal extends React.Component {
       shade,
       visible
     } = this.props;
-    return (
+    return ReactDOM.createPortal(
       <CSSTransition classNames="modal" in={visible} mountOnEnter timeout={200} unmountOnExit>
         <ThemeProvider theme={newTheme}>
           <ModalWrapper onClick={this.handleShadeClick} onKeyUp={this.handleEscKey} tabIndex={-1}>
@@ -222,18 +222,25 @@ class Modal extends React.Component {
             <RemoveScrollBar />
             <ModalBody onClick={(e) => e.stopPropagation()}>
               <CloseButton onClick={onClose} />
-              <ModalHeader align={align}>{headerText}</ModalHeader>
-              <ModalContent align={align}>
-                <p>{description}</p>
-                {children}
-              </ModalContent>
-              <ModalFooter align={align} fullWidthActionButtons={fullWidthActionButtons}>
-                {customFooter || this.getOrderedButtons()}
-              </ModalFooter>
+              {children ? (
+                children
+              ) : (
+                <React.Fragment>
+                  <ModalHeader align={align}>{headerText}</ModalHeader>
+                  <ModalContent align={align}>
+                    {description && <p>{description}</p>}
+                    {children}
+                  </ModalContent>
+                  <ModalFooter align={align} fullWidthActionButtons={fullWidthActionButtons}>
+                    {customFooter || this.getOrderedButtons()}
+                  </ModalFooter>
+                </React.Fragment>
+              )}
             </ModalBody>
           </ModalWrapper>
         </ThemeProvider>
-      </CSSTransition>
+      </CSSTransition>,
+      document.body
     );
   }
 }
@@ -242,6 +249,4 @@ Modal.defaultProps = defaultProps;
 
 Modal.propTypes = propTypes;
 
-export default (props) => {
-  return ReactDOM.createPortal(<Modal {...props} />, document.body);
-};
+export default Modal;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -154,6 +154,16 @@ const CloseButton = ({ onClick }) => {
 };
 
 class Modal extends React.Component {
+  static Header({ children, ...rest }) {
+    return <ModalHeader {...rest}>{children}</ModalHeader>;
+  }
+  static Content({ children, ...rest }) {
+    return <ModalContent {...rest}>{children}</ModalContent>;
+  }
+  static Footer({ children, ...rest }) {
+    return <ModalFooter {...rest}>{children}</ModalFooter>;
+  }
+
   constructor(props) {
     super(props);
     this.setFocus = this.setFocus.bind(this);

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -6,6 +6,7 @@ import Button from '../Button/BlueButton';
 const ModalLauncher = () => {
   const [showStandard, setShowStandard] = useState(false);
   const [showC2A, setShowC2A] = useState(false);
+  const [showCustom, setShowCustom] = useState(false);
 
   const toggleStandard = () => {
     setShowStandard(!showStandard);
@@ -15,14 +16,16 @@ const ModalLauncher = () => {
     setShowC2A(!showC2A);
   };
 
+  const toggleCustom = () => {
+    setShowCustom(!showCustom);
+  };
+
   return (
     <React.Fragment>
       <Button onClick={toggleStandard}>Standard modal</Button>
       <Button onClick={toggleC2A}>C2A modal</Button>
+      <Button onClick={toggleCustom}>Custom modal</Button>
       <Modal
-        align="left"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunts ut labore Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunts ut labore et dolore magna aliqua.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunts ut labore et dolore magna aliqua.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunts ut labore et dolore magna aliqua.et dolore magna aliqua."
-        headerText="Este es el header"
         onCancel={toggleStandard}
         onClose={toggleStandard}
         onOk={toggleStandard}
@@ -38,6 +41,44 @@ const ModalLauncher = () => {
         onOk={toggleC2A}
         visible={showC2A}
       />
+      <Modal
+        onCancel={toggleCustom}
+        onClose={toggleCustom}
+        onOk={toggleCustom}
+        visible={showCustom}
+      >
+        <Modal.Header>Cabeza de modal</Modal.Header>
+        <Modal.Content scrollable>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+          sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit
+          amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+          tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+          do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+          do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem
+          ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+          do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+          aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+        </Modal.Content>
+      </Modal>
     </React.Fragment>
   );
 };

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -24,8 +24,11 @@ const ModalLauncher = () => {
     <React.Fragment>
       <Button onClick={toggleStandard}>Standard modal</Button>
       <Button onClick={toggleC2A}>C2A modal</Button>
-      <Button onClick={toggleCustom}>Custom modal</Button>
+      <Button onClick={toggleCustom}>Custom modal with scroll</Button>
       <Modal
+        align="left"
+        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+        headerText="Este es el header"
         onCancel={toggleStandard}
         onClose={toggleStandard}
         onOk={toggleStandard}
@@ -47,8 +50,8 @@ const ModalLauncher = () => {
         onOk={toggleCustom}
         visible={showCustom}
       >
-        <Modal.Header>Cabeza de modal</Modal.Header>
-        <Modal.Content scrollable>
+        <Modal.Header align="center">Header</Modal.Header>
+        <Modal.Content align="right" scrollable>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
           ut labore et dolore magna aliqua Lorem ipsum dolor sit amet, consectetur adipiscing elit,
           sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Lorem ipsum dolor sit

--- a/src/components/Modal/ModalContent.js
+++ b/src/components/Modal/ModalContent.js
@@ -2,20 +2,28 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Container = styled.div`
-  overflow-y: auto;
+  overflow: hidden;
   text-align: ${(props) => props.align};
   overflow-wrap: break-word;
   font-family: ${(props) => props.theme.typography.bodyFontFamily};
   font-size: ${(props) => props.theme.typography.bodyFontSizes[0]};
   line-height: ${(props) => props.theme.typography.bodyLineHeights[0]};
   font-weight: 400;
+  &.scrollable {
+    overflow-y: auto;
+    max-height: 60vh;
+  }
   & p {
     margin: 0;
   }
 `;
 
-const ModalContent = ({ align, children }) => {
-  return <Container align={align}>{children}</Container>;
+const ModalContent = ({ align, children, scrollable }) => {
+  return (
+    <Container align={align} className={scrollable && 'scrollable'}>
+      {children}
+    </Container>
+  );
 };
 
 export default ModalContent;


### PR DESCRIPTION
Enable scroll on modal content through `scrollable` prop.
Now internal modal components as Header, Content and Footer are exposed through static methods enabling finer control over modal contents.